### PR TITLE
feat: Integrate 10 shared asafo skills

### DIFF
--- a/okyerema/.github/skills/doc-coauthoring/SKILL.md
+++ b/okyerema/.github/skills/doc-coauthoring/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: doc-coauthoring
+description: Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.
+---
+
+# Doc Co-Authoring Workflow
+
+Walk users through three stages of collaborative document creation: Context Gathering, Refinement & Structure, and Reader Testing.
+
+## When to Offer This Workflow
+
+**Trigger conditions:**
+- User mentions writing documentation: "write a doc", "draft a proposal", "create a spec"
+- User mentions specific doc types: "PRD", "design doc", "decision doc", "RFC"
+- User is starting a substantial writing task
+
+**Initial offer:** Explain the three stages and ask if they want structured or freeform.
+
+## Stage 1: Context Gathering
+
+Close the gap between what the user knows and what the agent knows.
+
+### Initial Questions
+1. What type of document is this?
+2. Who's the primary audience?
+3. What's the desired impact when someone reads this?
+4. Is there a template or specific format to follow?
+5. Any other constraints or context?
+
+### Info Dumping
+Encourage the user to dump all context:
+- Background on the project/problem
+- Related discussions or documents
+- Why alternatives aren't being used
+- Organizational context, timeline pressures
+- Technical architecture or dependencies
+
+After the initial dump, ask 5-10 clarifying questions based on gaps.
+
+**Exit condition:** Questions show understanding — edge cases and trade-offs can be discussed without needing basics explained.
+
+## Stage 2: Refinement & Structure
+
+Build the document section by section through brainstorming, curation, and iterative refinement.
+
+### For Each Section
+1. **Clarify**: Ask 5-10 questions about what to include
+2. **Brainstorm**: Generate 5-20 options for content
+3. **Curate**: User selects what to keep/remove/combine
+4. **Gap Check**: Ask if anything important is missing
+5. **Draft**: Write the section based on selections
+6. **Refine**: Make surgical edits based on feedback (never reprint whole doc)
+
+### Key Instructions
+- Start with whichever section has the most unknowns
+- Ask user to indicate changes rather than editing directly (helps learn their style)
+- After 3 consecutive iterations with no substantial changes, suggest removing unnecessary content
+
+### Near Completion (80%+ done)
+Re-read entire document and check for:
+- Flow and consistency across sections
+- Redundancy or contradictions
+- Generic filler that doesn't carry weight
+
+## Stage 3: Reader Testing
+
+Test the document with a fresh perspective to catch blind spots.
+
+### Steps
+1. **Predict reader questions**: Generate 5-10 questions readers would realistically ask
+2. **Test**: Use a sub-agent (if available) or ask user to test in a fresh conversation
+3. **Additional checks**: Look for ambiguity, false assumptions, contradictions
+4. **Fix gaps**: Loop back to refinement for any problematic sections
+
+**Exit condition:** Reader consistently answers questions correctly with no new gaps.
+
+## Final Review
+
+When reader testing passes:
+1. Recommend a final read-through by the user
+2. Suggest double-checking facts, links, technical details
+3. Ask if it achieves the intended impact
+
+## Tips
+- Be direct and procedural in tone
+- If user wants to skip a stage, let them
+- Address context gaps as they come up — don't let them accumulate
+- Use surgical edits (str_replace), never reprint the whole doc
+
+## Attribution
+
+From [anthropics/skills](https://github.com/anthropics/skills) `doc-coauthoring` skill (Apache 2.0 License).

--- a/okyerema/.github/skills/docx/SKILL.md
+++ b/okyerema/.github/skills/docx/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: docx
+description: "Use this skill whenever the user wants to create, read, edit, or manipulate Word documents (.docx files). Triggers include: any mention of \"Word doc\", \"word document\", \".docx\", or requests to produce professional documents with formatting like tables of contents, headings, page numbers, or letterheads. Also use when extracting content from .docx files, working with tracked changes or comments, or converting content into a polished Word document."
+---
+
+# DOCX Creation, Editing, and Analysis
+
+A .docx file is a ZIP archive containing XML files.
+
+## Quick Reference
+
+| Task | Approach |
+|------|----------|
+| Read/analyze content | `pandoc` or unpack for raw XML |
+| Create new document | Use `docx-js` (`npm install -g docx`) |
+| Edit existing document | Unpack → edit XML → repack |
+
+## Creating New Documents (docx-js)
+
+```javascript
+const { Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell,
+        ImageRun, Header, Footer, HeadingLevel, PageBreak } = require('docx');
+
+const doc = new Document({ sections: [{ children: [/* content */] }] });
+Packer.toBuffer(doc).then(buffer => fs.writeFileSync("doc.docx", buffer));
+```
+
+### Critical Rules
+- **Set page size explicitly** — defaults to A4; use 12240×15840 DXA for US Letter
+- **Never use `\n`** — use separate Paragraph elements
+- **Never use unicode bullets** — use `LevelFormat.BULLET` with numbering config
+- **PageBreak must be in Paragraph** — standalone creates invalid XML
+- **ImageRun requires `type`** — always specify png/jpg/etc
+- **Tables need dual widths** — `columnWidths` AND cell `width`, both must match
+- **Always use `WidthType.DXA`** — never `PERCENTAGE` (breaks in Google Docs)
+- **Use `ShadingType.CLEAR`** — never SOLID for table shading
+
+### Validation
+```bash
+python scripts/office/validate.py doc.docx
+```
+
+## Editing Existing Documents
+
+### Step 1: Unpack
+```bash
+python scripts/office/unpack.py document.docx unpacked/
+```
+
+### Step 2: Edit XML
+Edit files in `unpacked/word/`. Use smart quotes (`&#x201C;`, `&#x201D;`, `&#x2019;`).
+
+**Tracked Changes:**
+```xml
+<w:ins w:id="1" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:r><w:t>inserted text</w:t></w:r>
+</w:ins>
+<w:del w:id="2" w:author="Claude" w:date="2025-01-01T00:00:00Z">
+  <w:r><w:delText>deleted text</w:delText></w:r>
+</w:del>
+```
+
+### Step 3: Pack
+```bash
+python scripts/office/pack.py unpacked/ output.docx --original document.docx
+```
+
+## Reading Content
+
+```bash
+pandoc --track-changes=all document.docx -o output.md
+python scripts/office/unpack.py document.docx unpacked/
+```
+
+## Attribution
+
+From [anthropics/skills](https://github.com/anthropics/skills) `docx` skill (Proprietary — see LICENSE.txt in source repo for terms).

--- a/okyerema/.github/skills/github-issue-creator/SKILL.md
+++ b/okyerema/.github/skills/github-issue-creator/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: github-issue-creator
+description: Convert raw notes, error logs, voice dictation, or screenshots into structured GitHub-flavored markdown issue reports. Use when creating issues from unstructured input, converting meeting notes to action items, or structuring bug reports from user feedback. Adapted from microsoft/skills for the Anokye System.
+---
+
+# GitHub Issue Creator
+
+Convert unstructured input into well-structured GitHub issues using org-standard issue types (Epic, Feature, Task, Bug) and GraphQL mutations.
+
+## When to Use
+
+- Raw meeting notes with action items
+- Error logs or stack traces that need bug reports
+- Voice dictation or quick notes to formalize
+- Screenshots with annotations to document
+- User feedback to convert into feature requests
+
+## Issue Structure
+
+### Required Fields
+- **Title**: Clear, action-oriented (verb + noun)
+- **Body**: Structured markdown with sections
+- **Issue Type**: Epic, Feature, Task, or Bug (use org issue type IDs)
+
+### Body Template
+```markdown
+## Summary
+[1-2 sentence description of what and why]
+
+## Details
+[Expanded context, requirements, or reproduction steps]
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Notes
+[Additional context, links, references]
+```
+
+## Issue Type Selection
+
+| Type | When to Use |
+|------|------------|
+| **Epic** | Large initiative spanning multiple features |
+| **Feature** | User-facing capability or enhancement |
+| **Task** | Implementation work, chore, or technical item |
+| **Bug** | Defect, regression, or unexpected behavior |
+
+## Creation via GraphQL
+
+Always use GraphQL mutations (never REST) for issue creation:
+
+```graphql
+mutation {
+  createIssue(input: {
+    repositoryId: "<REPO_ID>"
+    title: "<title>"
+    body: "<body>"
+    issueTypeId: "<ISSUE_TYPE_ID>"
+  }) {
+    issue { number url }
+  }
+}
+```
+
+## From Raw Notes
+
+When given unstructured input:
+1. **Extract** the core intent (what needs to happen)
+2. **Classify** as Epic, Feature, Task, or Bug
+3. **Structure** with title, summary, details, acceptance criteria
+4. **Enrich** with labels, assignees, or parent links if context available
+
+## Best Practices
+
+- Titles should be scannable: `Add retry logic to webhook delivery` not `Webhook issue`
+- Include reproduction steps for bugs (Given/When/Then)
+- Link to related issues using `#number` references
+- Use sub-issues API for parent-child relationships
+- One issue per concern — don't combine unrelated items
+
+## Attribution
+
+Adapted from [microsoft/skills](https://github.com/microsoft/skills) `github-issue-creator` skill (MIT License).

--- a/okyerema/.github/skills/internal-comms/SKILL.md
+++ b/okyerema/.github/skills/internal-comms/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: internal-comms
+description: Resources for writing internal communications — status reports, leadership updates, 3P updates, company newsletters, FAQs, incident reports, and project updates. Use when asked to write any sort of internal communication. Complements Okyeame status reporting patterns (/sitrep, /recap).
+---
+
+# Internal Communications
+
+## When to Use
+
+Write any kind of internal communication:
+- 3P updates (Progress, Plans, Problems)
+- Status reports and leadership updates
+- Company newsletters
+- FAQ responses
+- Project updates
+- Incident reports
+
+## Communication Types
+
+### 3P Update (Progress, Plans, Problems)
+
+```markdown
+## Progress (What happened)
+- [Completed item with impact]
+- [Milestone reached]
+
+## Plans (What's next)
+- [Upcoming work with timeline]
+- [Dependencies or coordination needed]
+
+## Problems (What's blocked)
+- [Blocker]: [Impact]. [Ask/mitigation].
+```
+
+### Leadership Update
+
+```markdown
+Status: [Green / Yellow / Red]
+
+TL;DR: [One sentence — the most important thing to know]
+
+Progress:
+- [Outcome tied to goal/OKR]
+
+Risks:
+- [Risk]: [Mitigation]. [Ask if needed].
+
+Decisions needed:
+- [Decision]: [Options with recommendation]. Need by [date].
+```
+
+### Incident Report
+
+```markdown
+## Incident Summary
+- **What happened**: [Brief description]
+- **Impact**: [Who was affected, severity, duration]
+- **Root cause**: [What went wrong]
+- **Resolution**: [How it was fixed]
+
+## Timeline
+- [Time]: [Event]
+
+## Action Items
+- [ ] [Preventive measure] — Owner: [name], Due: [date]
+```
+
+### Project Update
+
+```markdown
+## Status: [On Track / At Risk / Off Track]
+
+### Completed This Period
+- [Item with link to PR/issue]
+
+### In Progress
+- [Item] — [Owner]. [Expected completion].
+
+### Blocked
+- [Item]: [Blocker]. [What's needed to unblock].
+
+### Next Period
+- [Planned work]
+```
+
+## Writing Guidelines
+
+- **Lead with the conclusion**, not the journey
+- **Be specific**: "Shipped auth module, reduced login time by 40%" not "Made progress on auth"
+- **Keep it scannable**: bullets, headers, bold for key terms
+- **Status colors matter**: Yellow is proactive risk management, not failure
+- **Asks must be specific**: "Decision on X by Friday" not "support needed"
+- **Match the audience**: executives want strategy, engineers want details
+
+## Keywords
+
+3P updates, company newsletter, weekly update, status report, leadership update, FAQs, incident report, project update, internal comms
+
+## Attribution
+
+From [anthropics/skills](https://github.com/anthropics/skills) `internal-comms` skill (see LICENSE.txt in source repo for terms).

--- a/okyerema/.github/skills/pdf/SKILL.md
+++ b/okyerema/.github/skills/pdf/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: pdf
+description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+---
+
+# PDF Processing Guide
+
+## Quick Start
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```
+
+## Quick Reference
+
+| Task | Best Tool | Key Code |
+|------|-----------|----------|
+| Merge PDFs | pypdf | `writer.add_page(page)` |
+| Split PDFs | pypdf | One page per file |
+| Extract text | pdfplumber | `page.extract_text()` |
+| Extract tables | pdfplumber | `page.extract_tables()` |
+| Create PDFs | reportlab | Canvas or Platypus |
+| OCR scanned PDFs | pytesseract | Convert to image first |
+| Command line merge | qpdf | `qpdf --empty --pages ...` |
+
+## Python Libraries
+
+### pypdf — Merge, Split, Rotate, Encrypt
+
+```python
+from pypdf import PdfWriter, PdfReader
+
+# Merge
+writer = PdfWriter()
+for pdf_file in ["doc1.pdf", "doc2.pdf"]:
+    for page in PdfReader(pdf_file).pages:
+        writer.add_page(page)
+with open("merged.pdf", "wb") as f:
+    writer.write(f)
+
+# Split
+reader = PdfReader("input.pdf")
+for i, page in enumerate(reader.pages):
+    w = PdfWriter()
+    w.add_page(page)
+    with open(f"page_{i+1}.pdf", "wb") as f:
+        w.write(f)
+
+# Rotate
+page = PdfReader("input.pdf").pages[0]
+page.rotate(90)
+
+# Encrypt
+writer.encrypt("userpassword", "ownerpassword")
+```
+
+### pdfplumber — Text and Table Extraction
+
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        tables = page.extract_tables()
+```
+
+### reportlab — Create PDFs
+
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+c = canvas.Canvas("hello.pdf", pagesize=letter)
+c.drawString(100, 700, "Hello World!")
+c.save()
+```
+
+**IMPORTANT**: Never use Unicode subscript/superscript characters in ReportLab — use `<sub>` and `<super>` tags in Paragraph objects.
+
+## Command-Line Tools
+
+```bash
+# pdftotext (poppler-utils)
+pdftotext -layout input.pdf output.txt
+
+# qpdf
+qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
+qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
+```
+
+## Common Tasks
+
+### OCR Scanned PDFs
+```python
+import pytesseract
+from pdf2image import convert_from_path
+
+images = convert_from_path('scanned.pdf')
+for image in images:
+    text = pytesseract.image_to_string(image)
+```
+
+### Add Watermark
+```python
+watermark = PdfReader("watermark.pdf").pages[0]
+for page in PdfReader("document.pdf").pages:
+    page.merge_page(watermark)
+```
+
+### Extract Images
+```bash
+pdfimages -j input.pdf output_prefix
+```
+
+## Attribution
+
+From [anthropics/skills](https://github.com/anthropics/skills) `pdf` skill (Proprietary — see LICENSE.txt in source repo for terms).

--- a/okyerema/.github/skills/pptx/SKILL.md
+++ b/okyerema/.github/skills/pptx/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: pptx
+description: "Use this skill any time a .pptx file is involved — as input, output, or both. This includes: creating slide decks, pitch decks, or presentations; reading or extracting text from .pptx files; editing or updating existing presentations; working with templates, layouts, speaker notes, or comments. Trigger whenever the user mentions \"deck,\" \"slides,\" \"presentation,\" or references a .pptx filename."
+---
+
+# PPTX Skill
+
+## Quick Reference
+
+| Task | Guide |
+|------|-------|
+| Read/analyze content | `python -m markitdown presentation.pptx` |
+| Edit or create from template | Unpack → manipulate slides → pack |
+| Create from scratch | Use `pptxgenjs` (`npm install -g pptxgenjs`) |
+
+## Reading Content
+
+```bash
+python -m markitdown presentation.pptx    # Text extraction
+python scripts/thumbnail.py presentation.pptx  # Visual overview
+python scripts/office/unpack.py presentation.pptx unpacked/  # Raw XML
+```
+
+## Design Principles
+
+**Don't create boring slides.** Every slide needs a visual element — image, chart, icon, or shape.
+
+### Before Starting
+- Pick a bold, content-informed color palette specific to THIS topic
+- One color dominates (60-70%), 1-2 supporting tones, one accent
+- Dark backgrounds for title + conclusion, light for content
+- Commit to ONE visual motif and repeat it
+
+### Layout Options
+- Two-column (text left, illustration right)
+- Icon + text rows
+- 2×2 or 2×3 grid
+- Half-bleed image with content overlay
+- Large stat callouts (60-72pt numbers)
+
+### Typography
+- Slide title: 36-44pt bold
+- Section header: 20-24pt bold
+- Body text: 14-16pt
+- Captions: 10-12pt muted
+- 0.5" minimum margins
+
+### Avoid
+- Don't repeat the same layout across slides
+- Don't center body text (left-align; center only titles)
+- Don't default to blue — match the topic
+- Don't create text-only slides
+- NEVER use accent lines under titles (hallmark of AI-generated slides)
+
+## QA (Required)
+
+**Assume there are problems. Your job is to find them.**
+
+### Content QA
+```bash
+python -m markitdown output.pptx
+python -m markitdown output.pptx | grep -iE "xxxx|lorem|ipsum"
+```
+
+### Visual QA
+Convert to images and inspect:
+```bash
+python scripts/office/soffice.py --headless --convert-to pdf output.pptx
+pdftoppm -jpeg -r 150 output.pdf slide
+```
+
+Check for: overlapping elements, text overflow, low contrast, uneven gaps, leftover placeholders.
+
+### Verification Loop
+1. Generate → Convert to images → Inspect
+2. List issues (if none, look again more critically)
+3. Fix issues → Re-verify affected slides
+4. Repeat until clean pass
+
+## Dependencies
+
+- `pip install "markitdown[pptx]"` — text extraction
+- `npm install -g pptxgenjs` — creating from scratch
+- LibreOffice — PDF conversion
+- Poppler (`pdftoppm`) — PDF to images
+
+## Attribution
+
+From [anthropics/skills](https://github.com/anthropics/skills) `pptx` skill (Proprietary — see LICENSE.txt in source repo for terms).

--- a/okyerema/.github/skills/product-management/SKILL.md
+++ b/okyerema/.github/skills/product-management/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: product-management
+description: "Use this skill for product management tasks: writing PRDs and feature specs, managing roadmaps, stakeholder communications, competitive analysis, metrics tracking, and user research synthesis. Triggers: \"PRD\", \"feature spec\", \"roadmap\", \"stakeholder update\", \"competitive analysis\", \"metrics\", \"OKR\", \"user research\", \"persona\", \"RICE score\"."
+---
+
+# Product Management
+
+A unified skill for product strategy, planning, and communication.
+
+## Capabilities
+
+| Domain | Use When |
+|--------|----------|
+| Feature Spec | Writing PRDs, user stories, acceptance criteria |
+| Roadmap | Prioritizing features, capacity planning, Now/Next/Later |
+| Stakeholder Comms | Executive updates, ADRs, engineering briefs |
+| Competitive Analysis | Landscape mapping, feature comparison, positioning |
+| Metrics Tracking | North Star metrics, OKRs, dashboard design |
+| User Research | Thematic analysis, personas, opportunity sizing |
+
+## Feature Spec (PRD)
+
+### Structure
+1. **Problem Statement** — What problem, who has it, evidence
+2. **Proposed Solution** — High-level approach, key features
+3. **User Stories** — `As a [role], I want [action] so that [benefit]`
+4. **Acceptance Criteria** — Given/When/Then format
+5. **Technical Considerations** — Architecture, dependencies, risks
+6. **Success Metrics** — How we'll measure impact
+7. **Timeline** — Milestones and phases
+
+### User Story Template
+```markdown
+**As a** [user role]
+**I want** [capability]
+**So that** [business value]
+
+Acceptance Criteria:
+- [ ] Given [context], when [action], then [result]
+```
+
+## Roadmap Management
+
+### Now / Next / Later Framework
+- **Now** (0-6 weeks): Committed, resourced, in progress
+- **Next** (6-12 weeks): Planned, scoped, awaiting capacity
+- **Later** (3-6 months): Directional, needs validation
+
+### Prioritization: RICE
+- **Reach**: How many users affected per quarter?
+- **Impact**: How much does it move the metric? (3=massive, 2=high, 1=medium, 0.5=low, 0.25=minimal)
+- **Confidence**: How sure are we? (100%=high, 80%=medium, 50%=low)
+- **Effort**: Person-months to ship
+
+**Score = (Reach × Impact × Confidence) / Effort**
+
+### MoSCoW for scope decisions
+- **Must have**: Ship fails without it
+- **Should have**: Important but workaround exists
+- **Could have**: Nice-to-have, cut if needed
+- **Won't have**: Explicitly out of scope (this release)
+
+## Stakeholder Communications
+
+### Executive Update Template
+```markdown
+## [Product] Status — [Date]
+**Status**: 🟢 On Track / 🟡 At Risk / 🔴 Off Track
+
+### Key Outcomes
+- [Metric]: [Current] vs [Target] ([trend])
+
+### Decisions Needed
+1. [Decision]: [Options]. Recommend [X] because [reason]. Need by [date].
+
+### Risks (ROAM)
+- [Resolved | Owned | Accepted | Mitigated]: [Description]
+```
+
+### Architecture Decision Record (ADR)
+```markdown
+# ADR-[number]: [Title]
+**Status**: Proposed | Accepted | Deprecated | Superseded
+**Date**: [YYYY-MM-DD]
+
+## Context
+[Why this decision is needed]
+
+## Decision
+[What we decided]
+
+## Consequences
+- [Positive]: ...
+- [Negative]: ...
+- [Neutral]: ...
+```
+
+## Competitive Analysis
+
+### Landscape Map
+```markdown
+| Competitor | Positioning | Strengths | Weaknesses | Threat Level |
+|-----------|-------------|-----------|------------|-------------|
+| [Name] | [Market position] | [Key advantages] | [Key gaps] | High/Med/Low |
+```
+
+### Feature Comparison Matrix
+```markdown
+| Feature | Us | Comp A | Comp B |
+|---------|-------|--------|--------|
+| [Feature] | ✅ Full | ⚠️ Partial | ❌ None |
+```
+
+## Metrics & OKRs
+
+### North Star Metric
+One metric that captures core value delivery. All L1/L2 metrics ladder up to it.
+
+### OKR Template
+```markdown
+**Objective**: [Qualitative, inspirational goal]
+
+KR1: [Metric] from [baseline] to [target] by [date]
+KR2: [Metric] from [baseline] to [target] by [date]
+KR3: [Metric] from [baseline] to [target] by [date]
+```
+
+### Dashboard Design
+- Lead indicators (predict future): activation rate, feature adoption
+- Lag indicators (confirm past): revenue, churn, NPS
+
+## User Research Synthesis
+
+### Thematic Analysis
+1. Gather raw observations/quotes
+2. Code into themes (bottom-up)
+3. Group themes into categories
+4. Identify patterns across participants
+5. Quantify: "7 of 10 participants mentioned X"
+
+### Persona Template
+```markdown
+## [Name] — [Role/Archetype]
+**Demographics**: [Age range, role, company size]
+**Goals**: [What they're trying to achieve]
+**Pain Points**: [What frustrates them]
+**Behaviors**: [How they currently solve the problem]
+**Quote**: "[Representative quote from research]"
+```
+
+### Opportunity Sizing
+**TAM × SAM × SOM** or **# Users × Frequency × Value per use**
+
+## Attribution
+
+Consolidated from [anthropics/knowledge-work-plugins](https://github.com/anthropics/knowledge-work-plugins) `product-management` plugin (source-available license).

--- a/okyerema/.github/skills/productivity/SKILL.md
+++ b/okyerema/.github/skills/productivity/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: productivity
+description: "Use this skill for task management and memory/knowledge management. Triggers: tracking tasks, managing TODOs, creating task lists, remembering information across sessions, maintaining project context, glossaries, people directories, and session memory. Complements Okyerema's DAG tracking and Okyeame's status reporting."
+---
+
+# Productivity
+
+Task tracking and persistent memory management for development workflows.
+
+## Task Management
+
+### TASKS.md Format
+
+Maintain a `TASKS.md` file at the project root:
+
+```markdown
+# Tasks
+
+## In Progress
+- [ ] Implement auth module @alice
+- [ ] Fix pagination bug @bob #high
+
+## Blocked
+- [ ] Deploy to staging — waiting on DB migration
+  - Blocker: Need DBA approval (asked 2025-01-15)
+
+## Done
+- [x] Set up CI pipeline @alice
+- [x] Write API docs @bob
+```
+
+### Rules
+- One task per line, checkbox format
+- `@mention` for assignment
+- `#high`, `#medium`, `#low` for priority
+- Move between sections as status changes
+- Add sub-bullets for context, blockers, or notes
+- Date-stamp blockers and decisions
+
+### Task Lifecycle
+```
+New → In Progress → [Blocked ↔ In Progress] → Done
+```
+
+## Memory Management
+
+### Two-Tier System
+
+**Tier 1: CLAUDE.md** (root-level, always loaded)
+- Project conventions and rules
+- Key architectural decisions
+- Current sprint goals
+- Links to Tier 2 files
+
+**Tier 2: memory/ directory** (loaded on demand)
+- `memory/glossary.md` — Project-specific terms
+- `memory/people.md` — Team members, roles, preferences
+- `memory/projects.md` — Active projects and status
+- `memory/decisions.md` — Decision log with rationale
+
+### Glossary Format
+
+```markdown
+# Glossary
+
+| Term | Definition |
+|------|-----------|
+| Asafo | Implementation agents (warriors) |
+| Okyeame | Linguist agent — status, reporting, coordination |
+| Okyerema | Master drummer — keeps the rhythm, shared skills |
+| Adwoma | Work items — GitHub Issues as external memory |
+```
+
+### People Directory
+
+```markdown
+# People
+
+## [Name]
+- **Role**: [Title/Function]
+- **Handles**: @github, @slack
+- **Expertise**: [Key areas]
+- **Preferences**: [Communication style, review expectations]
+- **Current focus**: [What they're working on]
+```
+
+### Decision Log
+
+```markdown
+# Decisions
+
+## [YYYY-MM-DD] [Decision Title]
+**Context**: [Why this came up]
+**Decision**: [What was decided]
+**Alternatives considered**: [What else was evaluated]
+**Rationale**: [Why this option won]
+**Revisit if**: [Conditions that would change this]
+```
+
+## Integration with Anokye System
+
+- **Okyeame** uses task data for `/sitrep` and `/recap` commands
+- **Okyerema** maintains rhythm across tasks via DAG tracking
+- **Adwoma** (GitHub Issues) is the canonical source of truth — TASKS.md is a local working copy
+- Sync pattern: Issues → TASKS.md for local work, push status back to Issues
+
+## Attribution
+
+Consolidated from [anthropics/knowledge-work-plugins](https://github.com/anthropics/knowledge-work-plugins) `productivity` plugin (source-available license).

--- a/okyerema/.github/skills/skill-creator/SKILL.md
+++ b/okyerema/.github/skills/skill-creator/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: skill-creator
+description: Guide for creating effective skills that extend AI agent capabilities with specialized knowledge, workflows, or tool integrations. Use when creating a new skill, updating an existing skill, or reviewing skill design for quality and token efficiency. Adapted from microsoft/skills.
+---
+
+# Skill Creator Guide
+
+Create well-structured skills that follow progressive disclosure, maintain token efficiency, and provide clear activation triggers.
+
+## Skill File Structure
+
+Every skill needs a `SKILL.md` file with YAML frontmatter:
+
+```yaml
+---
+name: my-skill
+description: >
+  Trigger-rich description under 1024 chars. Include verbs and nouns
+  that users would naturally say. This is how the agent discovers
+  when to activate this skill.
+---
+```
+
+## Progressive Disclosure Architecture
+
+Skills load in three tiers to conserve context:
+
+### Tier 1: Metadata (30-50 tokens)
+- `name` and `description` from frontmatter
+- Always loaded — this is how the agent decides to activate
+- **Must be trigger-rich**: include action verbs, file types, domain terms
+
+### Tier 2: Instructions (<500 lines)
+- The SKILL.md body — loaded when skill activates
+- Core workflow, quick start, critical rules
+- **No preamble** — start with actionable content immediately
+
+### Tier 3: References (on-demand)
+- Files in `references/` directory — loaded only when needed
+- Detailed docs, examples, API specs, troubleshooting
+- Each file must be self-contained and focused
+
+## SKILL.md Authoring Rules
+
+### Frontmatter Description
+- **Under 1024 characters**
+- Use trigger phrases: verbs users say + nouns they mention
+- Focus on **when to use** over **what it does**
+- Bad: `"Helps with documents"` — too vague
+- Good: `"Use when creating Word docs, editing .docx files, generating reports with tables and formatting"`
+
+### Body Content
+- **Under 500 lines** — this is a hard budget
+- Start with a quick start or core workflow (no introductions)
+- Use imperative language: "Create the file" not "You should create the file"
+- Include concrete examples with input/output pairs
+- Link to `references/` for anything that would push over 500 lines
+
+### References Directory
+- Single depth only: `references/FILE.md` (no nesting)
+- Each file is self-contained — don't require reading multiple files
+- Name files descriptively: `MODELS.md`, `WORKFLOWS.md`, `API.md`
+- Include a brief description at the top of each reference file
+
+## Common Patterns
+
+### Workflow-Oriented Skills
+Organize around user workflows, not API endpoints:
+
+```markdown
+## Creating a Report
+1. Gather data from source
+2. Format using template
+3. Export to target format
+
+## Editing an Existing Report
+1. Load the file
+2. Apply changes
+3. Validate and save
+```
+
+### Tool Integration Skills
+When wrapping external tools or APIs:
+
+```markdown
+## Quick Start
+[Minimal example to get started]
+
+## Core Operations
+[3-5 most common operations with examples]
+
+## Error Handling
+[What to do when things go wrong — guide next steps]
+
+## References
+- [FULL_API.md](references/FULL_API.md) — Complete API reference
+- [EXAMPLES.md](references/EXAMPLES.md) — Extended examples
+```
+
+### Script-Backed Skills
+When skills include PowerShell or other scripts:
+
+```markdown
+## Available Scripts
+| Script | Purpose |
+|--------|---------|
+| `scripts/Do-Thing.ps1` | Brief description |
+
+## Usage
+[How and when to invoke each script]
+```
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It's Bad | Fix |
+|-------------|-------------|-----|
+| SKILL.md > 500 lines | Consumes context budget | Move detail to references/ |
+| Vague description | Agent can't discover skill | Add trigger verbs and nouns |
+| Nested references | Complexity, hard to find | Single-depth references/ only |
+| No examples | Agent guesses at usage | Add concrete input/output pairs |
+| API-oriented structure | Doesn't match user intent | Organize by workflow |
+| Generic error messages | Agent can't recover | Guide next steps in errors |
+
+## Quality Checklist
+
+- [ ] Frontmatter description < 1024 chars with trigger phrases
+- [ ] SKILL.md body < 500 lines
+- [ ] Quick start with no preamble
+- [ ] Concrete examples with input/output
+- [ ] References are single-depth and self-contained
+- [ ] Error responses guide next steps
+- [ ] Imperative language throughout
+- [ ] Consistent terminology
+
+## Attribution
+
+Adapted from [microsoft/skills](https://github.com/microsoft/skills) `skill-creator` skill (MIT License).

--- a/okyerema/.github/skills/xlsx/SKILL.md
+++ b/okyerema/.github/skills/xlsx/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: xlsx
+description: "Use this skill any time a spreadsheet file is the primary input or output. This means any task where the user wants to: open, read, edit, or fix an existing .xlsx, .xlsm, .csv, or .tsv file; create a new spreadsheet from scratch or from other data sources; or convert between tabular file formats. Trigger when the user references a spreadsheet file by name or path."
+---
+
+# XLSX Creation, Editing, and Analysis
+
+## Critical Rule: Use Formulas, Not Hardcoded Values
+
+**Always use Excel formulas instead of calculating in Python and hardcoding results.**
+
+```python
+# ❌ WRONG
+total = df['Sales'].sum()
+sheet['B10'] = total
+
+# ✅ CORRECT
+sheet['B10'] = '=SUM(B2:B9)'
+```
+
+## Quick Reference
+
+| Task | Tool |
+|------|------|
+| Data analysis | pandas |
+| Formulas & formatting | openpyxl |
+| Formula recalculation | `python scripts/recalc.py output.xlsx` |
+
+## Common Workflow
+
+1. Choose tool (pandas for data, openpyxl for formulas/formatting)
+2. Create/Load workbook
+3. Modify data, formulas, formatting
+4. Save
+5. **Recalculate formulas** (mandatory): `python scripts/recalc.py output.xlsx`
+6. Verify and fix any errors from recalc output
+
+## Creating Excel Files (openpyxl)
+
+```python
+from openpyxl import Workbook
+from openpyxl.styles import Font, PatternFill, Alignment
+
+wb = Workbook()
+sheet = wb.active
+sheet['A1'] = 'Revenue'
+sheet['B2'] = '=SUM(A1:A10)'
+sheet['A1'].font = Font(bold=True)
+sheet.column_dimensions['A'].width = 20
+wb.save('output.xlsx')
+```
+
+## Reading Data (pandas)
+
+```python
+import pandas as pd
+df = pd.read_excel('file.xlsx')
+all_sheets = pd.read_excel('file.xlsx', sheet_name=None)
+```
+
+## Financial Model Standards
+
+### Color Coding
+- **Blue text**: Hardcoded inputs
+- **Black text**: ALL formulas and calculations
+- **Green text**: Links from other worksheets
+- **Red text**: External links
+- **Yellow background**: Key assumptions needing attention
+
+### Number Formatting
+- Years as text strings ("2024" not "2,024")
+- Currency: `$#,##0` with units in headers
+- Zeros display as "-"
+- Percentages: `0.0%`
+- Negatives: parentheses `(123)` not `-123`
+
+## Formula Verification Checklist
+
+- [ ] Test 2-3 sample references before building full model
+- [ ] Confirm column mapping (column 64 = BL, not BK)
+- [ ] Row offset: DataFrame row 5 = Excel row 6
+- [ ] Handle NaN with `pd.notna()`
+- [ ] Check for #DIV/0!, #REF!, #VALUE! errors after recalc
+
+## Attribution
+
+From [anthropics/skills](https://github.com/anthropics/skills) `xlsx` skill (Proprietary — see LICENSE.txt in source repo for terms).


### PR DESCRIPTION
## Summary

Integrates 10 shared skills from Microsoft and Anthropic repos as asafo skills available to all agents.

### Skills Added

**From microsoft/skills:**
- **github-issue-creator** — GraphQL-based issue creation with org issue types
- **skill-creator** — Guidelines for creating GitHub Copilot skills

**From anthropics/skills:**
- **doc-coauthoring** — 3-stage document co-authoring workflow
- **pdf** — PDF read/write/merge/split/OCR
- **docx** — Word document creation and XML editing
- **xlsx** — Spreadsheet creation with formulas and formatting
- **pptx** — Presentation creation with design guidelines

**From anthropics/knowledge-work-plugins:**
- **internal-comms** — Status reports, 3P updates, incident reports
- **product-management** — PRDs, roadmaps, stakeholder comms, competitive analysis, metrics, user research
- **productivity** — Task tracking and memory management

### Location
All skills placed under \okyerema/.github/skills/\ as shared asafo capabilities.

Closes #20, #21, #22, #23, #24, #25, #26
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
