### PR TITLE
fix: use closingIssuesReferences API for linked issue check

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Check PR body for linked issue
+      - name: Check for linked issue
         uses: actions/github-script@v7
         with:
           script: |
@@ -24,21 +24,32 @@ jobs:
               return;
             }
 
-            const body = context.payload.pull_request.body || '';
+            const result = await github.graphql(`
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    closingIssuesReferences(first: 1) {
+                      totalCount
+                    }
+                  }
+                }
+              }
+            `, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pr: context.payload.pull_request.number,
+            });
 
-            // Match closing keywords followed by an issue number or full URL
-            const keywordPattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:#(\d+)|https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+))/gi;
-            const matches = body.match(keywordPattern);
+            const count = result.repository.pullRequest.closingIssuesReferences.totalCount;
 
-            if (!matches) {
+            if (count === 0) {
               core.setFailed(
-                'This PR must reference a linked issue.\n\n' +
-                'Add one of the following to your PR description:\n' +
-                '  Closes #N\n' +
-                '  Fixes #N\n' +
-                '  Resolves #N\n\n' +
+                'This PR must be linked to a GitHub issue.\n\n' +
+                'Link an issue using either method:\n' +
+                '  1. Development sidebar: click "Link an issue" in the PR sidebar\n' +
+                '  2. PR description: add "Closes #N", "Fixes #N", or "Resolves #N"\n\n' +
                 'Replace N with the issue number this PR addresses.'
               );
             } else {
-              core.info(`Found linked issue reference(s): ${matches.join(', ')}`);
+              core.info(`PR has ${count} linked issue(s).`);
             }

--- a/BRANCH-PROTECTION.md
+++ b/BRANCH-PROTECTION.md
@@ -125,15 +125,12 @@ You need admin permissions on the repository to configure branch protection. Con
 
 ### "PR is missing a linked issue"
 
-Add a closing keyword to your PR description:
+Link an issue using either method:
 
-```
-Closes #123
-```
+1. **Development sidebar** (recommended) — click "Link an issue" in the PR sidebar
+2. **PR description** — add `Closes #N`, `Fixes #N`, or `Resolves #N`
 
-Supported keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved`.
-
-The check re-runs automatically when you edit the PR description. Bot PRs (dependabot, github-actions) are exempt.
+The check queries GitHub's `closingIssuesReferences` API, so both methods are equally valid. It re-runs automatically when the PR is updated. Bot PRs (dependabot, github-actions) are exempt.
 
 ### "Failed to query branch protection rules"
 


### PR DESCRIPTION
Replaces body keyword regex with a GraphQL query against `closingIssuesReferences`. PRs can now satisfy the check by either linking via the **Development sidebar** or using keywords in the body — both methods work.

Closes #176
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
