### PR TITLE
ci: add auto-enqueue workflow and copilot-swe-agent to trusted actors

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -81,25 +81,44 @@ jobs:
               ref: headSha,
               per_page: 100,
             });
+
+            // Use latest completed run per check name to avoid stale results
+            function latestConclusion(checkRuns, name) {
+              const matches = checkRuns
+                .filter(r => r.name === name && r.status === 'completed')
+                .sort((a, b) => new Date(b.completed_at) - new Date(a.completed_at));
+              return matches.length > 0 ? matches[0].conclusion : null;
+            }
+
             const allPassed = requiredChecks.every(name =>
-              checkData.check_runs.some(r => r.name === name && r.conclusion === 'success')
+              latestConclusion(checkData.check_runs, name) === 'success'
             );
             if (!allPassed) {
               core.info('Not all required checks have passed yet; auto-enqueue.yml will handle enqueueing.');
               return;
             }
 
-            const threads = await github.graphql(`
-              query($owner:String!,$repo:String!,$pr:Int!) {
-                repository(owner:$owner,name:$repo) {
-                  pullRequest(number:$pr) {
-                    reviewThreads(first:20) { nodes { isResolved } }
+            // Paginate review threads to check for unresolved conversations
+            let hasUnresolved = false;
+            let cursor = null;
+            do {
+              const threads = await github.graphql(`
+                query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+                  repository(owner:$owner,name:$repo) {
+                    pullRequest(number:$pr) {
+                      reviewThreads(first:100,after:$cursor) {
+                        nodes { isResolved }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                    }
                   }
                 }
-              }
-            `, { owner: context.repo.owner, repo: context.repo.repo, pr: prNumber });
+              `, { owner: context.repo.owner, repo: context.repo.repo, pr: prNumber, cursor });
+              const page = threads.repository.pullRequest.reviewThreads;
+              if (page.nodes.some(t => !t.isResolved)) { hasUnresolved = true; break; }
+              cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+            } while (cursor);
 
-            const hasUnresolved = threads.repository.pullRequest.reviewThreads.nodes.some(t => !t.isResolved);
             if (hasUnresolved) {
               core.info('PR has unresolved review threads; skipping enqueue.');
               return;

--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -24,12 +24,21 @@ jobs:
             const requiredChecks = ['Static Validation', 'Check Linked Issue'];
             const headSha = context.payload.check_run.head_sha;
 
-            // Find open PRs targeting main whose head matches this check run
-            const { data: prs } = await github.rest.pulls.list({
+            // Helper: get the latest check run conclusion for a given name
+            function latestConclusion(checkRuns, name) {
+              const matches = checkRuns
+                .filter(r => r.name === name && r.status === 'completed')
+                .sort((a, b) => new Date(b.completed_at) - new Date(a.completed_at));
+              return matches.length > 0 ? matches[0].conclusion : null;
+            }
+
+            // Paginate all open PRs targeting main
+            const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               base: 'main',
+              per_page: 100,
             });
 
             for (const pr of prs) {
@@ -39,7 +48,7 @@ jobs:
                 continue;
               }
 
-              // Verify all required checks have passed
+              // Verify latest run of each required check passed
               const { data: checkData } = await github.rest.checks.listForRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -47,7 +56,7 @@ jobs:
                 per_page: 100,
               });
               const allPassed = requiredChecks.every(name =>
-                checkData.check_runs.some(r => r.name === name && r.conclusion === 'success')
+                latestConclusion(checkData.check_runs, name) === 'success'
               );
               if (!allPassed) {
                 core.info(`PR #${pr.number}: not all required checks passed yet.`);
@@ -65,18 +74,27 @@ jobs:
                 continue;
               }
 
-              // Verify no unresolved review threads
-              const threads = await github.graphql(`
-                query($owner:String!,$repo:String!,$pr:Int!) {
-                  repository(owner:$owner,name:$repo) {
-                    pullRequest(number:$pr) {
-                      reviewThreads(first:20) { nodes { isResolved } }
+              // Paginate review threads to check for unresolved conversations
+              let hasUnresolved = false;
+              let cursor = null;
+              do {
+                const threads = await github.graphql(`
+                  query($owner:String!,$repo:String!,$pr:Int!,$cursor:String) {
+                    repository(owner:$owner,name:$repo) {
+                      pullRequest(number:$pr) {
+                        reviewThreads(first:100,after:$cursor) {
+                          nodes { isResolved }
+                          pageInfo { hasNextPage endCursor }
+                        }
+                      }
                     }
                   }
-                }
-              `, { owner: context.repo.owner, repo: context.repo.repo, pr: pr.number });
+                `, { owner: context.repo.owner, repo: context.repo.repo, pr: pr.number, cursor });
+                const page = threads.repository.pullRequest.reviewThreads;
+                if (page.nodes.some(t => !t.isResolved)) { hasUnresolved = true; break; }
+                cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+              } while (cursor);
 
-              const hasUnresolved = threads.repository.pullRequest.reviewThreads.nodes.some(t => !t.isResolved);
               if (hasUnresolved) {
                 core.info(`PR #${pr.number}: has unresolved review threads, skipping.`);
                 continue;


### PR DESCRIPTION
Fixes two gaps in the agent-only PR lifecycle:

1. **`copilot-swe-agent`** added to trusted actors (both `copilot-swe-agent[bot]` and `app/copilot-swe-agent` login formats)
2. **Auto-enqueue race condition**: GitHub doesn't re-evaluate merge queue enqueue when `enablePullRequestAutoMerge` is called after all checks have already completed. Two fixes:
   - `auto-approve.yml` now enqueues immediately if all checks already passed when it runs
   - New `auto-enqueue.yml` fires on `check_run` completed for required checks, enqueues any ready PRs

Closes #183
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
