### PR TITLE
ci: fix agent PR pipeline — draft handling, ahuofe validation, auto-enqueue trigger

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,11 +2,13 @@ name: Auto Approve
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 jobs:
   auto-approve:
     name: Auto Approve
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -1,17 +1,14 @@
 name: Auto Enqueue
 
 on:
-  check_run:
+  workflow_run:
+    workflows: ["Validate Plugin", "Require Linked Issue"]
     types: [completed]
 
 jobs:
   auto-enqueue:
     name: Auto Enqueue
-    # Only run when a required check succeeds — avoids unnecessary runs
-    if: |
-      github.event.check_run.conclusion == 'success' &&
-      (github.event.check_run.name == 'Static Validation' ||
-       github.event.check_run.name == 'Check Linked Issue')
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -22,7 +19,7 @@ jobs:
         with:
           script: |
             const requiredChecks = ['Static Validation', 'Check Linked Issue'];
-            const headSha = context.payload.check_run.head_sha;
+            const headSha = context.payload.workflow_run.head_sha;
 
             // Helper: get the latest check run conclusion for a given name
             function latestConclusion(checkRuns, name) {
@@ -32,7 +29,7 @@ jobs:
               return matches.length > 0 ? matches[0].conclusion : null;
             }
 
-            // Paginate all open PRs targeting main
+            // Find open PRs matching the head SHA from the completed workflow
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -43,6 +40,10 @@ jobs:
 
             for (const pr of prs) {
               if (pr.head.sha !== headSha) continue;
+              if (pr.draft) {
+                core.info(`PR #${pr.number}: is a draft, skipping.`);
+                continue;
+              }
               if (!pr.auto_merge) {
                 core.info(`PR #${pr.number}: auto-merge not enabled, skipping.`);
                 continue;

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -2,7 +2,7 @@ name: Require Linked Issue
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
     branches: [main]
   merge_group:
 

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -7,8 +7,10 @@ on:
     paths:
       - 'omanfo/**'
       - 'okyeame/**'
+      - 'ahuofe/**'
       - '.github/workflows/**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
   merge_group:
 
@@ -50,6 +52,15 @@ jobs:
           else
             echo "omanfo_changed=false" >> $GITHUB_OUTPUT
             echo "○ omanfo has no changes"
+          fi
+          
+          # Check if ahuofe has changes
+          if echo "$CHANGED_FILES" | grep -q "^ahuofe/"; then
+            echo "ahuofe_changed=true" >> $GITHUB_OUTPUT
+            echo "✓ ahuofe has changes"
+          else
+            echo "ahuofe_changed=false" >> $GITHUB_OUTPUT
+            echo "○ ahuofe has no changes"
           fi
           
           # Check if okyeame has changes
@@ -167,6 +178,63 @@ jobs:
           Write-Host "`n═══════════════════════════════════════" -ForegroundColor Cyan
           if ($failures -eq 0) {
             Write-Host "   ✅ ALL OKYEAME VALIDATIONS PASSED" -ForegroundColor Green
+            Write-Host "═══════════════════════════════════════`n" -ForegroundColor Cyan
+            exit 0
+          } else {
+            Write-Host "   ❌ $failures VALIDATION(S) FAILED" -ForegroundColor Red
+            Write-Host "═══════════════════════════════════════`n" -ForegroundColor Cyan
+            exit 1
+          }
+      
+      - name: Validate ahuofe plugin
+        if: steps.changes.outputs.ahuofe_changed == 'true'
+        shell: pwsh
+        run: |
+          Write-Host "`n═══════════════════════════════════════" -ForegroundColor Cyan
+          Write-Host "       VALIDATING AHUOFE PLUGIN" -ForegroundColor Cyan
+          Write-Host "═══════════════════════════════════════`n" -ForegroundColor Cyan
+          
+          $failures = 0
+          
+          # Test 1: Manifest Consistency
+          Write-Host "`n▶ Running Test-ManifestConsistency..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-ManifestConsistency.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Test 2: File Structure
+          Write-Host "`n▶ Running Test-FileStructure..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-FileStructure.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Test 3: PowerShell Syntax
+          Write-Host "`n▶ Running Test-PowerShellSyntax..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-PowerShellSyntax.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Test 4: SKILL.md Quality
+          Write-Host "`n▶ Running Test-SkillQuality..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-SkillQuality.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Test 5: Evaluation Coverage
+          Write-Host "`n▶ Running Test-EvalCoverage..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-EvalCoverage.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Test 6: Markdown Structure
+          Write-Host "`n▶ Running Test-MarkdownStructure..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-MarkdownStructure.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Test 7: Script Test Coverage
+          Write-Host "`n▶ Running Test-ScriptTestCoverage..." -ForegroundColor Blue
+          & ./omanfo/scripts/validation/Test-ScriptTestCoverage.ps1 -PluginPath ahuofe
+          if ($LASTEXITCODE -ne 0) { $failures++ }
+          
+          # Summary
+          Write-Host "`n═══════════════════════════════════════" -ForegroundColor Cyan
+          if ($failures -eq 0) {
+            Write-Host "   ✅ ALL AHUOFE VALIDATIONS PASSED" -ForegroundColor Green
             Write-Host "═══════════════════════════════════════`n" -ForegroundColor Cyan
             exit 0
           } else {


### PR DESCRIPTION
Fix four issues preventing agent PRs from flowing through the automated pipeline:

## Problems
1. **13 Copilot draft PRs stuck** — \uto-approve.yml\ doesn't fire on \eady_for_review\, so marking drafts ready has no effect
2. **\uto-enqueue.yml\ had 0 runs** — Uses \check_run\ trigger which GitHub prevents from cascading between workflows
3. **\alidate-plugin.yml\ ignores ahuofe** — No \huofe/**\ path filter and no ahuofe validation step
4. **\equire-linked-issue.yml\ missing \eady_for_review\** — Same draft handling gap

## Fixes
- **auto-approve.yml**: Add \eady_for_review\ trigger + skip drafts with \if: !github.event.pull_request.draft\
- **auto-enqueue.yml**: Switch from \check_run\ to \workflow_run\ trigger on \Validate Plugin\ and \Require Linked Issue\ + skip drafts
- **validate-plugin.yml**: Add \eady_for_review\ trigger, \huofe/**\ path, ahuofe change detection + validation step
- **require-linked-issue.yml**: Add \eady_for_review\ to types

After this merges, marking the 13 draft Copilot PRs as ready will trigger the full pipeline automatically.

Closes #53
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
