### PR TITLE
fix(ci): add Copilot to trusted actors in auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -25,6 +25,7 @@ jobs:
               'devin-ai-integration[bot]',
               'claude[bot]',
               'chatgpt-codex-connector[bot]',
+              'Copilot',
               'copilot-swe-agent[bot]',
               'app/copilot-swe-agent',
             ];


### PR DESCRIPTION
GitHub Copilot SWE agent PRs have user.login = Copilot (not copilot-swe-agent[bot]), causing auto-approve to skip all Copilot PRs. Adds Copilot to the trusted actors list.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
