### PR TITLE
fix: validate-plugin queue trigger

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches-ignore:
       - main
-    paths:
-      - 'omanfo/**'
-      - 'okyeame/**'
-      - 'ahuofe/**'
-      - '.github/workflows/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]


### PR DESCRIPTION
Closes #215

Removes path filter from push trigger so Static Validation runs on merge queue branches. Internal change detection already skips unchanged plugins.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
