### PR TITLE
Fix: use pull_request_target for Copilot checks

### DIFF
--- a/.github/workflows/copilot-checks.yml
+++ b/.github/workflows/copilot-checks.yml
@@ -1,19 +1,20 @@
 name: Copilot PR Checks
 
 # Bridge workflow: runs required checks for Copilot-authored PRs.
-# The Copilot coding agent actor triggers action_required on pull_request events,
-# so we use workflow_run (which runs in default-branch context) to bypass that gate.
+# Using pull_request_target ensures this runs in the context of the base repo (with write permissions),
+# bypassing "action required" approval gates for PRs from bot accounts.
 
 on:
-  workflow_run:
-    workflows: ["Copilot coding agent"]
-    types: [completed]
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
 
 jobs:
-  # ── Gate: only run when Copilot finished on a PR branch ───────────────
+  # ── Gate: only run for Copilot PRs ────────────────────────────────────
   resolve-pr:
     name: Resolve PR
     runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'copilot/')
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
       pr_node_id: ${{ steps.pr.outputs.node_id }}
@@ -21,43 +22,15 @@ jobs:
       head_ref: ${{ steps.pr.outputs.head_ref }}
       skip: ${{ steps.pr.outputs.skip }}
     steps:
-      - name: Find PR for branch
+      - name: Set PR context
         id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const wr = context.payload.workflow_run;
-            const branch = wr.head_branch;
-            const sha = wr.head_sha;
-
-            // Only care about copilot branches
-            if (!branch.startsWith('copilot/')) {
-              core.setOutput('skip', 'true');
-              core.info(`Skipping non-copilot branch: ${branch}`);
-              return;
-            }
-
-            const { data: prs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head: `${context.repo.owner}:${branch}`,
-              state: 'open',
-              per_page: 1,
-            });
-
-            if (prs.length === 0) {
-              core.setOutput('skip', 'true');
-              core.info(`No open PR for branch ${branch}`);
-              return;
-            }
-
-            const pr = prs[0];
-            core.setOutput('skip', 'false');
-            core.setOutput('number', String(pr.number));
-            core.setOutput('node_id', pr.node_id);
-            core.setOutput('head_sha', sha);
-            core.setOutput('head_ref', branch);
-            core.info(`Found PR #${pr.number} for branch ${branch} at ${sha}`);
+        run: |
+          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "node_id=${{ github.event.pull_request.node_id }}" >> $GITHUB_OUTPUT
+          echo "head_sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          echo "head_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Found PR #${{ github.event.pull_request.number }} from branch ${{ github.event.pull_request.head.ref }}"
 
   # ── Required check: Static Validation ─────────────────────────────────
   validate:


### PR DESCRIPTION
Fixes #239. Switching from workflow_run to pull_request_target ensures the workflow runs in the context of the base repository with write permissions, avoiding the 'action_required' approval block for bot-created PRs. Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>