### PR TITLE
Fix: trigger Copilot checks on ready_for_review

### DIFF
--- a/.github/workflows/copilot-checks.yml
+++ b/.github/workflows/copilot-checks.yml
@@ -7,7 +7,7 @@ name: Copilot PR Checks
 on:
   pull_request_target:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   # ── Gate: only run for Copilot PRs ────────────────────────────────────


### PR DESCRIPTION
Fixes #239. Ensures checks run immediately when a Copilot PR is marked as ready for review. Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>