### PR TITLE
fix(ci): merge main into Copilot PR branches before activation

### DIFF
--- a/.github/workflows/copilot-checks.yml
+++ b/.github/workflows/copilot-checks.yml
@@ -229,6 +229,22 @@ jobs:
             const prNumber = parseInt('${{ needs.resolve-pr.outputs.pr_number }}', 10);
             const prNodeId = '${{ needs.resolve-pr.outputs.pr_node_id }}';
 
+            // Merge main into PR branch — triggers synchronize event so
+            // validate-plugin.yml and require-linked-issue.yml fire as github-actions[bot],
+            // producing required status checks on the PR HEAD SHA.
+            try {
+              await github.rest.pulls.updateBranch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              core.info(`Merged main into PR #${prNumber} branch.`);
+              // Wait for push to propagate before marking ready
+              await new Promise(r => setTimeout(r, 5000));
+            } catch (e) {
+              core.info(`Branch update (may already be up-to-date): ${e.message}`);
+            }
+
             // Mark draft PRs ready for review — Copilot creates PRs as drafts,
             // and the require-linked-issue workflow may not have run due to approval gates.
             const { data: pr } = await github.rest.pulls.get({


### PR DESCRIPTION
## Summary

Fixes the missing 'Static Validation' required check on Copilot PRs.

### Problem
The \copilot-checks.yml\ \workflow_dispatch\ runs produce check results associated with main's HEAD SHA, not the PR's HEAD SHA. Branch protection requires checks on the PR HEAD, so 'Static Validation' was never satisfied.

### Fix
Before marking a Copilot draft PR ready for review, merge main into the PR branch via \pulls.updateBranch()\. This:
1. Rebases the PR onto latest main
2. Creates a \synchronize\ event triggered by \github-actions[bot]\
3. Fires \alidate-plugin.yml\ and \equire-linked-issue.yml\ as a trusted actor
4. Produces required checks on the correct PR HEAD SHA

Closes #286
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
