### PR TITLE
fix(ci): handle merge conflicts via Copilot resolution

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -53,9 +53,11 @@ jobs:
               // For workflow_run events, only process the PR that triggered it
               if (targetSha && pr.head.sha !== targetSha) continue;
 
-              // Copilot draft PRs: dispatch copilot-checks.yml to validate and activate.
+              // Copilot PRs (draft or non-draft): dispatch copilot-checks.yml to validate and activate.
               // GITHUB_TOKEN can trigger workflow_dispatch (Sept 2022 exception).
-              if (pr.draft && pr.head.ref.startsWith('copilot/')
+              // Non-draft Copilot PRs still need dispatch because synchronize events from
+              // Copilot conflict-resolution pushes get action_required.
+              if (pr.head.ref.startsWith('copilot/')
                   && ['Copilot', 'copilot-swe-agent[bot]'].includes(pr.user.login)) {
                 // Verify the PR has a linked issue before dispatching
                 const linked = await github.graphql(`
@@ -69,8 +71,26 @@ jobs:
                 `, { owner: context.repo.owner, repo: context.repo.repo, pr: pr.number });
 
                 if (linked.repository.pullRequest.closingIssuesReferences.totalCount === 0) {
-                  core.info(`PR #${pr.number}: Copilot draft with no linked issue, skipping.`);
+                  core.info(`PR #${pr.number}: Copilot PR with no linked issue, skipping.`);
                   continue;
+                }
+
+                // Skip if already enqueued in merge queue
+                if (pr.auto_merge) {
+                  // Check if required checks already pass on HEAD
+                  const { data: checkData } = await github.rest.checks.listForRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: pr.head.sha,
+                    per_page: 100,
+                  });
+                  const allPassed = requiredChecks.every(name =>
+                    latestConclusion(checkData.check_runs, name) === 'success'
+                  );
+                  if (allPassed) {
+                    core.info(`PR #${pr.number}: Copilot PR already has passing checks, skipping dispatch.`);
+                    continue;
+                  }
                 }
 
                 try {
@@ -82,7 +102,7 @@ jobs:
                     inputs: { pr_number: String(pr.number) },
                   });
                   dispatched++;
-                  core.info(`PR #${pr.number}: dispatched copilot-checks.yml for Copilot draft PR.`);
+                  core.info(`PR #${pr.number}: dispatched copilot-checks.yml for Copilot PR.`);
                 } catch (e) {
                   core.info(`PR #${pr.number}: dispatch failed: ${e.message}`);
                 }

--- a/.github/workflows/copilot-checks.yml
+++ b/.github/workflows/copilot-checks.yml
@@ -231,6 +231,7 @@ jobs:
             const prNodeId = '${{ needs.resolve-pr.outputs.pr_node_id }}';
 
             // Merge main into PR branch so it's up-to-date before merging.
+            let hasConflict = false;
             try {
               await github.rest.pulls.updateBranch({
                 owner: context.repo.owner,
@@ -240,6 +241,27 @@ jobs:
               core.info(`Merged main into PR #${prNumber} branch.`);
               await new Promise(r => setTimeout(r, 5000));
             } catch (e) {
+              if (e.status === 422 && e.message.includes('merge conflict')) {
+                hasConflict = true;
+                core.info(`PR #${prNumber} has merge conflicts — requesting Copilot resolution.`);
+                // Ask Copilot to resolve the conflict via @mention
+                const marker = '<!-- copilot-conflict-resolution -->';
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  per_page: 50,
+                });
+                if (!comments.some(c => c.body.includes(marker))) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    body: `${marker}\n@copilot This PR has merge conflicts with \`main\`. Please resolve the conflicts and push a fix commit.`,
+                  });
+                }
+                return; // Stop here — Copilot will push a fix, next sweep retries
+              }
               core.info(`Branch update (may already be up-to-date): ${e.message}`);
             }
 


### PR DESCRIPTION
When updateBranch hits a merge conflict, comments on the PR asking Copilot to resolve it. Also broadens auto-enqueue dispatch to cover non-draft Copilot PRs (needed after conflict-resolution pushes). Closes #178
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
