### PR TITLE
docs(ahuofe): add v2 setup guide, local iteration guide, update architecture and README

### DIFF
--- a/ahuofe/README.md
+++ b/ahuofe/README.md
@@ -61,6 +61,43 @@ Provides core functions used by all scripts:
 | `Test-ImageSorcery.ps1` | Test ImageSorcery MCP connection |
 | `Upload-ToFalCDN.ps1` | Upload files to fal.ai CDN |
 
+## v2 Capabilities
+
+Ahuofe v2 adds a PR-driven iterative media generation system on top of the existing Copilot skills and scripts. Project repos define brand entities in YAML, and Ahuofe handles generation, evaluation, and approval through GitHub Actions and PR comments.
+
+- **Pipeline** -- TypeScript generation engine with a 6-stage workflow: load YAML, compile prompt, generate reference sheet, generate panel, evaluate drift, and loop until consistency threshold is met
+- **Schemas** -- JSON Schema validation for brand YAML files (`schema/entity.schema.json`, `shared.schema.json`, `preset.schema.json`), ensuring entity definitions are correct before generation
+- **Workflows** -- Reusable GitHub Actions workflows (`workflow-templates/`) that project repos call via thin wrappers, handling draft/review/finalize stages with human approval gates
+- **Viewer** -- Lineage browser (`viewer/`) for browsing generation history, comparing outputs side-by-side, and viewing drift evaluation reports, deployed to GitHub Pages
+
+### Quick Start (v2)
+
+1. Add `.ahuofe.yaml` to your project repo root (see [Setup Guide](docs/SETUP_GUIDE.md) for the full config reference)
+2. Create a `brand/` directory with entity YAML files and stage presets
+3. Add the thin workflow wrapper at `.github/workflows/ahuofe.yml`
+4. Configure `FAL_KEY` and `ANTHROPIC_API_KEY` as GitHub Actions secrets
+5. Push a branch that edits brand files, open a PR -- draft generation runs automatically
+
+### Local Iteration
+
+Iterate on brand YAML files locally without API keys:
+
+```bash
+npx ahuofe validate --brand ./brand              # Validate YAML against schemas
+npx ahuofe preview-prompt --entity okyeame --brand ./brand  # Preview compiled prompt
+npx ahuofe mock-generate --entity okyeame --brand ./brand   # Generate placeholder images
+```
+
+See [Local Iteration Guide](docs/LOCAL_ITERATION.md) for the full workflow.
+
+### Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Setup Guide](docs/SETUP_GUIDE.md) | How to configure a project repo to use Ahuofe |
+| [Local Iteration](docs/LOCAL_ITERATION.md) | Local development workflow without API keys |
+| [Architecture](docs/ARCHITECTURE.md) | System architecture, pipeline design, data flow |
+
 ## Installation
 
 ### Prerequisites

--- a/ahuofe/docs/ARCHITECTURE.md
+++ b/ahuofe/docs/ARCHITECTURE.md
@@ -250,3 +250,218 @@ All tests use [Pester 5](https://pester.dev/) and can be run with:
 ```powershell
 Invoke-Pester -Path tests/
 ```
+
+---
+
+## v2: PR-Driven Iterative Media Generation
+
+The following sections describe the v2 architecture, which adds a TypeScript generation pipeline, reusable GitHub Actions workflows, JSON Schema validation, and a lineage viewer on top of the existing Copilot skills and PowerShell scripts.
+
+### v2 Directory Structure
+
+```
+ahuofe/
+├── pipeline/                  # NEW: TypeScript generation engine
+│   ├── src/
+│   │   ├── stages/            # 6-stage pipeline
+│   │   │   ├── load-yaml.ts
+│   │   │   ├── compile-prompt.ts
+│   │   │   ├── reference-sheet.ts
+│   │   │   ├── generate-panel.ts
+│   │   │   ├── evaluate-drift.ts
+│   │   │   └── loop.ts
+│   │   ├── actions/           # GitHub Actions integration layer
+│   │   │   ├── parse-comment.ts
+│   │   │   ├── post-results.ts
+│   │   │   ├── diff-brand.ts
+│   │   │   ├── prune-generations.ts
+│   │   │   └── request-approval.ts
+│   │   ├── local/             # Local iteration mode (no API keys)
+│   │   │   ├── validate-yaml.ts
+│   │   │   ├── mock-generate.ts
+│   │   │   └── preview-prompt.ts
+│   │   ├── fal/               # fal.ai integration with retention controls
+│   │   │   ├── client.ts
+│   │   │   ├── cleanup.ts
+│   │   │   └── config.ts
+│   │   ├── config.ts
+│   │   ├── types.ts
+│   │   └── index.ts
+│   ├── package.json
+│   └── tsconfig.json
+├── schema/                    # NEW: JSON Schema for brand YAML validation
+│   ├── entity.schema.json
+│   ├── shared.schema.json
+│   └── preset.schema.json
+├── workflow-templates/        # NEW: Reusable GitHub Actions workflows
+│   ├── ahuofe-generate.yml
+│   ├── ahuofe-evaluate.yml
+│   └── ahuofe-cleanup.yml
+├── viewer/                    # NEW: Lineage browser (static site)
+│   ├── index.html
+│   ├── embed.js
+│   └── assets/
+├── scripts/                   # Existing: PowerShell scripts
+│   ├── FalAi.psm1
+│   └── ...
+├── skills/                    # Existing: Copilot skill definitions
+│   ├── fal-ai/
+│   ├── fal-workflow/
+│   ├── image-sorcery/
+│   └── media-agents/
+├── docs/                      # Updated: Documentation
+│   ├── ARCHITECTURE.md
+│   ├── SETUP_GUIDE.md
+│   ├── LOCAL_ITERATION.md
+│   └── RESEARCH_INSIGHTS.md
+└── README.md
+```
+
+### Cross-Repo Binding Model
+
+Ahuofe is a **plugin** that lives in `anokye-labs/plugins/ahuofe`. Brand files do NOT live in the plugin. Instead, project repos (e.g., `anokye-system`) contain their own `brand/` directories with entity YAML files, and bind to the plugin via a `.ahuofe.yaml` config file at the repo root.
+
+```
+┌──────────────────────────────────┐    ┌──────────────────────────────────┐
+│  anokye-labs/plugins/ahuofe      │    │  anokye-labs/anokye-system       │
+│  (THE PLUGIN — reusable)         │    │  (A PROJECT REPO — uses plugin)  │
+│                                  │    │                                  │
+│  pipeline/    → generation code  │◄───│  .ahuofe.yaml  → binding config │
+│  schema/      → validation rules │    │  brand/         → YAML entities  │
+│  workflow-templates/ → Actions   │◄───│  .github/workflows/ahuofe.yml   │
+│  viewer/      → lineage browser  │    │                   (thin wrapper) │
+│  scripts/     → PowerShell       │    │                                  │
+│  skills/      → Copilot          │    │                                  │
+└──────────────────────────────────┘    └──────────────────────────────────┘
+```
+
+The `.ahuofe.yaml` config specifies:
+- Which plugin repo/ref to use
+- Where brand files live in the project
+- Model selections and cost thresholds per stage
+- Approval gate configuration
+- fal.ai retention policies
+- Secret name mappings
+
+See [SETUP_GUIDE.md](SETUP_GUIDE.md) for the full config reference.
+
+### Ephemeral Storage Model
+
+Generated images flow through a short lifecycle designed to avoid repo bloat and external storage costs:
+
+```
+fal.ai CDN              Actions Runner             PR Branch              main
+─────────               ──────────────             ─────────              ────
+  │                          │                         │                    │
+  │  1. Generate image       │                         │                    │
+  │◄─── POST with ephemeral  │                         │                    │
+  │     lifecycle headers    │                         │                    │
+  │                          │                         │                    │
+  │  2. Download immediately │                         │                    │
+  │────────────────────────► │                         │                    │
+  │                          │                         │                    │
+  │  3. Explicit DELETE      │  4. git commit + push   │                    │
+  │◄─────────────────────────│────────────────────────►│                    │
+  │  (belt-and-suspenders)   │                         │                    │
+  │                          │  5. Prune old gens      │                    │
+  │  6. CDN auto-expires     │────────────────────────►│ (git rm + commit)  │
+  │     (safety net)         │                         │                    │
+  │                          │                         │  7. Squash merge   │
+  │                          │                         │───────────────────►│
+  │                          │                         │  (only HEAD files) │
+  │                          │                         │                    │
+  │                          │                         │  8. Branch deleted  │
+  │                          │                         X  (GC'd by git)    │
+```
+
+Key principles:
+- **fal.ai never retains images** -- three layers of protection: lifecycle headers, explicit deletion, account-level settings
+- **PR branch is a scratchpad** -- images are pruned after each stage escalation
+- **Squash merge is essential** -- only files at HEAD (finalized images) land on main
+- **Branch auto-deletion** -- once deleted, intermediate commits are unreachable and garbage-collected
+
+### Pipeline Architecture
+
+The TypeScript pipeline processes brand YAML files through six stages:
+
+```
+                    ┌─────────────┐
+                    │  load-yaml  │  Read entity YAML + shared files
+                    └──────┬──────┘  Resolve cross-references
+                           │
+                    ┌──────▼──────┐
+                    │compile-prompt│  YAML → generation prompt text
+                    └──────┬──────┘  Include drift checklist + negatives
+                           │
+                    ┌──────▼──────────┐
+                    │ reference-sheet  │  Generate reference image (final only)
+                    └──────┬──────────┘  Establishes visual baseline
+                           │
+                    ┌──────▼──────────┐
+                    │ generate-panel   │  Call fal.ai with ephemeral headers
+                    └──────┬──────────┘  Download + delete from CDN
+                           │
+                    ┌──────▼──────────┐
+                    │ evaluate-drift   │  Compare output against brand spec
+                    └──────┬──────────┘  Rule-based (draft) or vision (final)
+                           │
+                    ┌──────▼──────┐
+                    │    loop     │  If drift score < threshold and
+                    └──────┬──────┘  iterations remaining, go to generate
+                           │
+                     Pass / Max iterations
+                           │
+                    ┌──────▼──────┐
+                    │   Output    │  Images + manifest + drift report
+                    └─────────────┘
+```
+
+The pipeline supports three stage configurations with escalating cost and quality:
+
+| Aspect | Draft | Review | Final |
+|--------|-------|--------|-------|
+| Model | nano-banana-2 | flux-pro | flux-pro/kontext/max/multi |
+| Reference sheet | Skip | Skip | Generate first |
+| Iterations | 1 | 1 | Up to 3 |
+| Drift evaluation | Rule-based | Rule-based + summary | Claude vision |
+| Approval required | No | Yes | Yes |
+
+### PR-Driven Iteration Flow
+
+```
+ User edits brand YAML → pushes → opens PR
+     │
+     ▼
+ ┌─── DRAFT (automatic, no approval) ──────────────────────────────┐
+ │  diff-brand.ts detects changed entities                         │
+ │  Pipeline runs with draft preset (cheap, fast)                  │
+ │  Images committed to PR branch, gallery posted as PR comment    │
+ └──────────────────────────────────────┬──────────────────────────┘
+                                        │
+     User reviews drafts, posts "@ahuofe review okyeame"
+                                        │
+ ┌─── REVIEW (approval gate) ──────────▼───────────────────────────┐
+ │  Bot posts: "Review generation requested. Approve?"             │
+ │  Authorized approver posts "@ahuofe approve"                    │
+ │  Pipeline runs with review preset (mid-tier model)              │
+ │  Old drafts pruned, review images committed, gallery updated    │
+ └──────────────────────────────────────┬──────────────────────────┘
+                                        │
+     User reviews, posts "@ahuofe finalize okyeame"
+                                        │
+ ┌─── FINALIZE (approval gate) ────────▼───────────────────────────┐
+ │  Bot posts: "Finalization requested. Est. cost: $X. Approve?"   │
+ │  Authorized approver posts "@ahuofe approve"                    │
+ │  Pipeline runs full consistency loop (expensive model + eval)   │
+ │  All previous images pruned, only finalized survive             │
+ │  "art-approved" label applied if drift score passes threshold   │
+ └──────────────────────────────────────┬──────────────────────────┘
+                                        │
+     Human reviews final art, approves PR via GitHub review
+                                        │
+ ┌─── MERGE ───────────────────────────▼───────────────────────────┐
+ │  Squash merge: all commits become one (only HEAD files)         │
+ │  Branch auto-deleted: intermediate generations garbage-collected│
+ │  Viewer manifests rebuilt, deployed to GitHub Pages              │
+ └─────────────────────────────────────────────────────────────────┘
+```

--- a/ahuofe/docs/LOCAL_ITERATION.md
+++ b/ahuofe/docs/LOCAL_ITERATION.md
@@ -1,0 +1,284 @@
+# Local Iteration Guide
+
+Fast, free iteration on brand YAML files without needing fal.ai or Anthropic API keys. This is the primary development loop for editing entity descriptions, tweaking visual properties, and validating brand consistency before pushing to a PR.
+
+## Overview
+
+| Capability | Command | Needs API Keys? |
+|-----------|---------|-----------------|
+| YAML validation | `npx ahuofe validate` | No |
+| Prompt preview | `npx ahuofe preview-prompt` | No |
+| Drift checklist preview | `npx ahuofe preview-prompt --show-drift` | No |
+| Mock generation | `npx ahuofe mock-generate` | No |
+| Batch validation | `npx ahuofe validate --all` | No |
+| Actual image generation | `npx tsx pipeline/src/index.ts --stage generate ...` | Yes (`FAL_KEY`) |
+| Drift evaluation | `npx tsx pipeline/src/index.ts --stage evaluate ...` | Yes (`ANTHROPIC_API_KEY`) |
+
+The first five commands work entirely offline. The last two require API keys and are handled by GitHub Actions in the PR-driven workflow.
+
+## Installation
+
+```bash
+# From your project repo (e.g., anokye-system)
+npm install --save-dev @anokye-labs/ahuofe-pipeline
+```
+
+Or, if working directly with the plugin source:
+
+```bash
+cd path/to/plugins/ahuofe/pipeline && npm install
+```
+
+## 1. validate-yaml -- Schema Validation
+
+Validates brand YAML files against the JSON schemas provided by the plugin.
+
+### Usage
+
+```bash
+# Validate all brand files
+npx ahuofe validate --brand ./brand
+
+# Validate a specific entity
+npx ahuofe validate --brand ./brand --entity okyeame
+
+# Direct invocation via tsx
+npx tsx ahuofe/pipeline/src/local/validate-yaml.ts brand/entities/physical/okyeame.yaml
+```
+
+### What It Checks
+
+- Required fields are present
+- Type correctness (strings, numbers, arrays, etc.)
+- Cross-references resolve (e.g., referenced adinkra symbols exist in `adinkra-map.yaml`)
+- Differentiation matrix consistency across entities
+- Color values are valid hex codes
+- Material references match entries in `shared/materials.yaml`
+
+### Output
+
+```
+brand/shared/colors.yaml .............. PASS
+brand/shared/materials.yaml ........... PASS
+brand/entities/physical/okyeame.yaml .. PASS
+brand/presets/draft.yaml .............. PASS
+brand/presets/review.yaml ............. PASS
+brand/presets/final.yaml .............. PASS
+
+6 files validated, 0 errors
+```
+
+On failure:
+
+```
+brand/entities/physical/okyeame.yaml .. FAIL
+  - /body/torso/primary_garment: required property 'material' is missing
+  - /head/helm/adinkra_symbol: "gye-nyame" not found in adinkra-map.yaml
+
+6 files validated, 2 errors
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All files valid |
+| 1 | Validation errors found |
+
+## 2. preview-prompt -- Prompt Compilation Preview
+
+Compiles entity YAML into the full generation prompt and prints it to stdout. Shows exactly what would be sent to fal.ai, so you can iterate on descriptions and see the effect instantly.
+
+### Usage
+
+```bash
+# Preview the compiled prompt for an entity
+npx ahuofe preview-prompt --entity okyeame --brand ./brand
+
+# Include the drift checklist and negative constraints
+npx ahuofe preview-prompt --entity okyeame --brand ./brand --show-drift
+
+# Direct invocation via tsx
+npx tsx ahuofe/pipeline/src/local/preview-prompt.ts --entity okyeame
+```
+
+### Output
+
+```
+=== Compiled Prompt for okyeame (idle-standing) ===
+
+A full-body digital illustration of The Linguist (Okyeame), a robotic-royal
+figure standing in an idle pose. The figure wears a golden helm adorned with
+the Gye Nyame adinkra symbol...
+
+[... full prompt text ...]
+
+--- Statistics ---
+Characters: 14,832
+Estimated tokens: ~3,708
+```
+
+With `--show-drift`:
+
+```
+=== Drift Checklist (22 items) ===
+ 1. Golden helm present on head
+ 2. Gye Nyame adinkra symbol on helm
+ 3. Linguist staff in right hand
+ 4. Kente cloth draped toga-style
+...
+
+=== Negative Constraints (14 items) ===
+ 1. NOT human skin visible
+ 2. NOT modern clothing
+ 3. NOT weapons other than linguist staff
+...
+```
+
+## 3. mock-generate -- Placeholder Generation
+
+Generates placeholder images locally for layout testing. No API keys required. Produces colored rectangles with entity name and pose text overlaid, matching the correct aspect ratios from the preset configuration.
+
+### Usage
+
+```bash
+# Mock-generate a single entity
+npx ahuofe mock-generate --entity okyeame --brand ./brand --output ./output
+
+# Mock-generate all entities
+npx ahuofe mock-generate --brand ./brand --all --output ./output
+
+# Direct invocation via tsx
+npx tsx ahuofe/pipeline/src/local/mock-generate.ts --entity okyeame
+```
+
+### What It Produces
+
+```
+output/
+├── okyeame/
+│   ├── idle-standing-v1.jpg       # Placeholder image (colored rectangle)
+│   └── manifest.json              # Manifest matching real generation format
+└── ...
+```
+
+The placeholder images:
+- Use entity-specific colors derived from the brand palette
+- Display entity name and pose as overlaid text
+- Match the aspect ratio specified in the active preset
+- Produce a `manifest.json` in the same format as real generations
+
+This is useful for:
+- Testing the viewer layout before spending API credits
+- Verifying PR comment formatting
+- Validating the full pipeline flow without network calls
+- Developing viewer features against realistic data structures
+
+## 4. Recommended Workflow
+
+The local iteration loop follows a validate-preview-mock cycle:
+
+```
+  Edit YAML
+      |
+      v
+  validate-yaml  ----> Fix errors ----> Edit YAML
+      |                                     ^
+      | (passes)                            |
+      v                                     |
+  preview-prompt ----> Tweak descriptions --+
+      |
+      | (satisfied with prompt)
+      v
+  mock-generate  ----> Check layout ------> Edit YAML
+      |                                     ^
+      | (satisfied with output)             |
+      v                                     |
+  Push to PR     ----> Review real images --+
+```
+
+### Step by Step
+
+```bash
+# 1. Clone the project repo
+git clone anokye-labs/anokye-system && cd anokye-system
+
+# 2. Install the pipeline
+npm install --save-dev @anokye-labs/ahuofe-pipeline
+
+# 3. Create a feature branch
+git checkout -b feature/okyeame-kente
+
+# 4. Edit a brand file
+vim brand/entities/physical/okyeame.yaml
+
+# 5. Validate immediately
+npx ahuofe validate --brand ./brand
+
+# 6. Preview the compiled prompt
+npx ahuofe preview-prompt --entity okyeame --brand ./brand
+
+# 7. Preview with drift checklist
+npx ahuofe preview-prompt --entity okyeame --brand ./brand --show-drift
+
+# 8. Generate mock images for layout testing
+npx ahuofe mock-generate --entity okyeame --brand ./brand --output ./output
+
+# 9. Repeat steps 4-8 until satisfied
+
+# 10. Push to open a PR -- Actions handles real generation
+git add brand/
+git commit -m "brand: refine okyeame kente draping"
+git push origin feature/okyeame-kente
+```
+
+## CLI Quick Reference
+
+```bash
+# Validate all brand files
+npx ahuofe validate --brand ./brand
+
+# Validate a specific entity
+npx ahuofe validate --brand ./brand --entity okyeame
+
+# Preview compiled prompt
+npx ahuofe preview-prompt --entity okyeame --brand ./brand
+
+# Preview with drift checklist
+npx ahuofe preview-prompt --entity okyeame --brand ./brand --show-drift
+
+# Mock generation (single entity)
+npx ahuofe mock-generate --entity okyeame --brand ./brand --output ./output
+
+# Mock batch generation (all entities)
+npx ahuofe mock-generate --brand ./brand --all --output ./output
+```
+
+## Troubleshooting
+
+### "Cannot find module @anokye-labs/ahuofe-pipeline"
+
+Ensure you have installed the pipeline package:
+
+```bash
+npm install --save-dev @anokye-labs/ahuofe-pipeline
+```
+
+### Validation passes but prompt preview looks wrong
+
+Check that `shared/` files are complete. The prompt compiler resolves cross-references to shared colors, materials, and adinkra symbols. Missing shared files may result in incomplete prompts without validation errors.
+
+### Mock images have wrong aspect ratio
+
+Check your `brand/presets/draft.yaml` -- the `aspect_ratio` field controls the dimensions of mock-generated images.
+
+## Next Steps
+
+Once you are satisfied with local iteration:
+
+1. Push your branch and open a PR
+2. The Ahuofe workflow runs draft generation automatically
+3. Review generated images in the PR comment gallery
+4. Use `@ahuofe review <entity>` and `@ahuofe finalize <entity>` to escalate
+
+See [SETUP_GUIDE.md](SETUP_GUIDE.md) for full project setup instructions.

--- a/ahuofe/docs/SETUP_GUIDE.md
+++ b/ahuofe/docs/SETUP_GUIDE.md
@@ -1,0 +1,245 @@
+# Ahuofe v2 Setup Guide
+
+How to configure a project repository to use the Ahuofe plugin for PR-driven iterative media generation.
+
+## Prerequisites
+
+- A GitHub repository for your project (e.g., `anokye-system`)
+- GitHub Actions enabled on the repository
+- Access to the `anokye-labs/plugins` repository (for reusable workflows)
+
+## 1. Create `.ahuofe.yaml`
+
+Add a `.ahuofe.yaml` file at the root of your project repository. This binds your project to the Ahuofe plugin and configures all generation behavior.
+
+```yaml
+# .ahuofe.yaml
+plugin:
+  repo: anokye-labs/plugins       # Repository containing the Ahuofe plugin
+  path: ahuofe                    # Path within the repo
+  ref: main                       # Pin to a tag for stability, or main for latest
+
+project:
+  name: "Anokye System"           # Human-readable project name
+  command_prefix: "@ahuofe"       # PR comment command prefix
+  viewer_title: "Anokye Brand Viewer"  # Title shown in the lineage viewer
+
+brand_path: "./brand"             # Path to brand directory, relative to repo root
+
+defaults:
+  stage: draft                    # Default generation stage
+  max_iterations: 3               # Max iterations for finalization loop
+  pass_threshold: 85              # Drift score threshold (0-100) for passing
+
+approval:
+  require_human_approval: true    # Enable approval gates
+  stages_requiring_approval:      # Which stages need human sign-off
+    - review                      # After initial drafts, human reviews direction
+    - finalize                    # Before running expensive final generation
+    - merge                       # Before merging finalized art to main
+  approvers:                      # GitHub usernames authorized to approve
+    - henry-somuah
+  auto_approve_draft: true        # Drafts can run without approval
+
+fal:
+  retention:
+    cdn_expiration_seconds: 3600  # Images expire from fal CDN after 1 hour
+    store_payloads: false         # Never store request payloads on fal.ai
+    delete_after_download: true   # Explicitly delete CDN files after downloading
+  models:
+    draft: fal-ai/nano-banana-2                   # Fast, cheap drafts
+    review: fal-ai/flux-pro                       # Mid-tier review quality
+    final: fal-ai/flux-pro/kontext/max/multi      # Full quality finalization
+    reference: fal-ai/flux-pro/kontext            # Reference sheet generation
+    evaluator: claude-sonnet-4-20250514           # Drift evaluation model
+
+secrets:                          # GitHub Actions secret names (never put values here)
+  fal_key: FAL_KEY
+  anthropic_key: ANTHROPIC_API_KEY
+
+notifications:
+  post_to_pr: true                # Post generation galleries to PR comments
+  label_on_pass: "art-approved"   # Label applied when all entities pass threshold
+```
+
+### Configuration Reference
+
+| Block | Purpose |
+|-------|---------|
+| `plugin` | Points to the Ahuofe plugin repository, path, and version |
+| `project` | Project identity: name, command prefix, viewer title |
+| `brand_path` | Where brand YAML files live, relative to repo root |
+| `defaults` | Default stage, iteration limits, and pass threshold |
+| `approval` | Human approval gate configuration |
+| `fal` | fal.ai retention controls and model selections per stage |
+| `secrets` | Maps logical secret names to GitHub Actions secret names |
+| `notifications` | PR notification and labeling behavior |
+
+## 2. Set Up Brand Directory Structure
+
+Create a `brand/` directory (or whatever `brand_path` points to) with the following layout:
+
+```
+brand/
+├── shared/                    # Shared visual properties across all entities
+│   ├── colors.yaml            # Color palette definitions (hex values)
+│   ├── materials.yaml         # Material descriptions (kente, gold, wood, etc.)
+│   ├── environment.yaml       # Background and environment settings
+│   ├── adinkra-map.yaml       # Adinkra symbol definitions and rendering rules
+│   ├── proportions.yaml       # Shared proportional guidelines
+│   └── differentiation-matrix.yaml  # Cross-entity differentiation rules
+├── entities/                  # Entity definitions (one YAML file per entity)
+│   ├── physical/              # Physical entities
+│   │   └── okyeame.yaml      # Example: The Linguist entity
+│   ├── virtual/               # Virtual entities
+│   │   └── asafo.yaml
+│   └── collective/            # Collective entities
+│       └── ahene-council.yaml
+└── presets/                   # Generation presets per stage
+    ├── draft.yaml             # Draft stage: fast, cheap, low quality
+    ├── review.yaml            # Review stage: mid-tier quality
+    └── final.yaml             # Final stage: production quality
+```
+
+### Preset Files
+
+Presets control generation behavior per stage. Example:
+
+```yaml
+# brand/presets/draft.yaml
+name: draft
+model: fal-ai/nano-banana-2
+reference_sheet: false
+max_iterations: 1
+drift_evaluation: quick         # Rule-based, no vision API
+output_format: jpg              # Smaller files for quick review
+quality: 80
+aspect_ratio: "16:9"
+requires_approval: false
+```
+
+```yaml
+# brand/presets/review.yaml
+name: review
+model: fal-ai/flux-pro
+reference_sheet: false
+max_iterations: 1
+drift_evaluation: quick_plus    # Rule-based + text summary
+output_format: jpg
+quality: 90
+aspect_ratio: "16:9"
+requires_approval: true
+```
+
+```yaml
+# brand/presets/final.yaml
+name: final
+model: fal-ai/flux-pro/kontext/max/multi
+reference_sheet: true
+reference_model: fal-ai/flux-pro/kontext
+max_iterations: 3
+pass_threshold: 85
+drift_evaluation: vision        # Claude vision API evaluation
+output_format: png              # Lossless for final assets
+aspect_ratio: "16:9"
+requires_approval: true
+```
+
+### Entity Files
+
+Entity YAML files define the visual properties of each entity at body-part-level granularity. They are validated against JSON schemas provided by the plugin (`ahuofe/schema/entity.schema.json`). See the plugin's schema directory for the full specification.
+
+## 3. Create Workflow Wrapper
+
+Add a thin workflow file to your project repo that delegates to the plugin's reusable workflows:
+
+```yaml
+# .github/workflows/ahuofe.yml
+name: Ahuofe Generate
+
+on:
+  pull_request:
+    paths:
+      - 'brand/**'
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  ahuofe:
+    uses: anokye-labs/plugins/.github/workflows/ahuofe-generate.yml@main
+    with:
+      config_path: .ahuofe.yaml
+      brand_path: brand/
+    secrets:
+      FAL_KEY: ${{ secrets.FAL_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+This workflow triggers on:
+- **Pull request events** when files under `brand/` are changed (opens draft generation automatically)
+- **Issue comments** on PRs (handles `@ahuofe` commands like `review`, `finalize`, `approve`)
+
+All pipeline logic, approval gates, pruning, and PR posting are handled by the plugin's reusable workflow.
+
+## 4. Configure Secrets
+
+Add the following secrets to your GitHub repository (Settings > Secrets and variables > Actions):
+
+| Secret | Description | Required For |
+|--------|-------------|-------------|
+| `FAL_KEY` | fal.ai API key for image generation | All generation stages (draft, review, final) |
+| `ANTHROPIC_API_KEY` | Anthropic API key for drift evaluation | Final stage (Claude vision evaluation) |
+
+These secrets are only used in GitHub Actions. Local iteration does not require API keys. See [LOCAL_ITERATION.md](LOCAL_ITERATION.md) for the local workflow.
+
+### fal.ai Account Configuration (Recommended)
+
+As an additional safety net, configure your fal.ai account's default retention policy:
+
+1. Go to https://fal.ai/settings
+2. Set default CDN retention to a short duration (e.g., 1 hour)
+3. This catches any request that somehow bypasses the per-request lifecycle headers
+
+## 5. Branch Protection (Recommended)
+
+Configure branch protection rules for your `main` branch to enforce the PR-driven workflow:
+
+| Setting | Recommended Value | Why |
+|---------|-------------------|-----|
+| Require pull request reviews | Yes (1 reviewer) | Human approval before merging art to main |
+| Require status checks | Yes (`ahuofe` job) | Ensure generation completed before merge |
+| Require squash merging | Yes | Only final images survive in main's history |
+| Auto-delete branches | Yes | Intermediate generations are garbage-collected |
+| Restrict pushes to main | Yes | All changes go through PRs |
+
+Squash merging is essential to the ephemeral storage model. When a PR with 20 generation/prune commits is squash-merged, only the files at HEAD (the final, approved images) become part of main's history. All intermediate generations that were pruned are permanently gone.
+
+## Verification Checklist
+
+After completing setup:
+
+- [ ] `.ahuofe.yaml` exists at the repo root with all required blocks
+- [ ] `brand/` directory contains at least one entity YAML file
+- [ ] `brand/presets/` contains `draft.yaml`, `review.yaml`, and `final.yaml`
+- [ ] `.github/workflows/ahuofe.yml` exists and references the correct plugin workflow
+- [ ] `FAL_KEY` secret is configured in GitHub repo settings
+- [ ] `ANTHROPIC_API_KEY` secret is configured in GitHub repo settings
+- [ ] Branch protection is configured with squash merge required
+- [ ] Auto-delete branches is enabled
+
+## What Happens Next
+
+1. Create a branch, edit a brand file under `brand/`, and open a PR
+2. The workflow detects the changed entities and runs draft generation automatically
+3. Draft images appear as a PR comment gallery with a drift checklist
+4. Use `@ahuofe review <entity>` to escalate to review quality (requires approval)
+5. Use `@ahuofe finalize <entity>` to run the full consistency loop (requires approval)
+6. Merge the PR -- only finalized images land on main
+
+For iterating on brand files locally without API keys, see [LOCAL_ITERATION.md](LOCAL_ITERATION.md).


### PR DESCRIPTION
## Summary
- **New: `ahuofe/docs/SETUP_GUIDE.md`** -- Complete guide for configuring a project repo to use the Ahuofe v2 plugin, covering `.ahuofe.yaml` config, brand directory structure, workflow wrapper, secrets, and branch protection
- **New: `ahuofe/docs/LOCAL_ITERATION.md`** -- Guide for the local-only workflow (no API keys needed): validate-yaml, preview-prompt, mock-generate, with recommended iteration loop and troubleshooting
- **Updated: `ahuofe/docs/ARCHITECTURE.md`** -- Added v2 sections: directory structure, cross-repo binding model, ephemeral storage model, 6-stage pipeline architecture, and PR-driven iteration flow diagram
- **Updated: `ahuofe/README.md`** -- Added v2 capabilities section, quick start steps, local iteration overview, and documentation links table

## Test plan
- [ ] Verify all markdown renders correctly on GitHub (no broken syntax, code fences balanced, tables formatted)
- [ ] Verify relative links resolve: README -> docs/SETUP_GUIDE.md, docs/LOCAL_ITERATION.md, docs/ARCHITECTURE.md
- [ ] Verify cross-links within docs/: SETUP_GUIDE <-> LOCAL_ITERATION, ARCHITECTURE -> SETUP_GUIDE
- [ ] Confirm existing README and ARCHITECTURE content is preserved (v2 content is additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/plugins/pull/337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
