### PR TITLE
fix(ci): fix Claude Code workflow for tag mode

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,15 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
-          prompt: |
-            ${{ github.event_name == 'issues' && format('Implement the feature described in this issue and create a PR referencing issue #{0}.\n\nIssue title: {1}\n\nIssue body:\n{2}', github.event.issue.number, github.event.issue.title, github.event.issue.body) || '' }}
+          prompt: "${{ github.event_name == 'issues' && format('Implement the feature described in this issue and create a PR referencing issue #{0}.\n\nIssue title: {1}\n\nIssue body:\n{2}', github.event.issue.number, github.event.issue.title, github.event.issue.body) || '' }}"


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission (OIDC auth)
- Add `actions/checkout@v4` step (tag mode requires repo checkout)
- Quote prompt expression to fix YAML parsing with `#` chars

Same fixes validated on amplifier-dotnet (see anokye-labs/amplifier-dotnet@027b3d6).

Closes #346

## Test plan
- [ ] Post an `@claude` comment on any issue and verify the workflow completes successfully
- [ ] Verify claude[bot] responds with a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)